### PR TITLE
Changing EnqueueOrWait to EnqueueOrWaitAsync

### DIFF
--- a/NUGET.md
+++ b/NUGET.md
@@ -1,6 +1,5 @@
-![SimpliSharp](https://github.com/cretucosmin3/SimpliSharp/blob/main/assets/simpli-sharp-dark.png?raw=true)
-
-**SimpliSharp is a C# utility library designed to streamline development with useful extensions, helpers, data processing tools, and logging helpers.**
+## SimpliSharp
+**A utility library designed to streamline development with useful extensions, helpers, data processing tools, and logging helpers.**
 
 [![.NET](https://github.com/cretucosmin3/SimpliSharp/actions/workflows/dotnet.yml/badge.svg)](https://github.com/cretucosmin3/SimpliSharp/actions/workflows/dotnet.yml)[![GitHub last commit](https://img.shields.io/github/last-commit/cretucosmin3/SimpliSharp.svg)](https://github.com/cretucosmin3/SimpliSharp/commits/main)
 [![GitHub stars](https://img.shields.io/github/stars/cretucosmin3/SimpliSharp.svg)](https://github.com/cretucosmin3/SimpliSharp/stargazers)
@@ -40,7 +39,7 @@ processor.OnException += (ex) => Console.WriteLine($"An error occurred: {ex.Mess
 // Enqueue items
 for (int i = 0; i < 100; i++)
 {
-    processor.EnqueueOrWait(i, data =>
+    processor.EnqueueOrWaitAsync(i, data =>
     {
         // Your processing logic here...
     });

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ processor.OnException += (ex) => Console.WriteLine($"An error occurred: {ex.Mess
 // Enqueue items
 for (int i = 0; i < 100; i++)
 {
-    processor.EnqueueOrWait(i, data =>
+    processor.EnqueueOrWaitAsync(i, data =>
     {
         // Your processing logic here...
     });

--- a/tests/SimpliSharp.Tests/Utilities/Process/SmartDataProcessor/SmartDataProcessorTests.cs
+++ b/tests/SimpliSharp.Tests/Utilities/Process/SmartDataProcessor/SmartDataProcessorTests.cs
@@ -22,7 +22,7 @@ public class SmartDataProcessorTests
         // Act
         for (int i = 0; i < 10; i++)
         {
-            processor.EnqueueOrWait(i, action);
+            processor.EnqueueOrWaitAsync(i, action).Wait();
         }
         await processor.WaitForAllAsync();
 
@@ -55,7 +55,7 @@ public class SmartDataProcessorTests
         // Act
         for (int i = 0; i < 5; i++)
         {
-            processor.EnqueueOrWait(i, action);
+            processor.EnqueueOrWaitAsync(i, action).Wait();
         }
 
         await Task.Delay(100); // Give time for tasks to start
@@ -88,12 +88,12 @@ public class SmartDataProcessorTests
         };
 
         // Act
-        processor.EnqueueOrWait(1, action);
+        processor.EnqueueOrWaitAsync(1, action).Wait();
         await Task.Delay(100); // Give the manager loop time to start
-        processor.EnqueueOrWait(2, action);
-        processor.EnqueueOrWait(3, action);
+        processor.EnqueueOrWaitAsync(2, action).Wait();
+        processor.EnqueueOrWaitAsync(3, action).Wait();
 
-        var blockedTask = Task.Run(() => processor.EnqueueOrWait(4, action));
+        var blockedTask = Task.Run(async () => await processor.EnqueueOrWaitAsync(4, action));
 
         await Task.Delay(100);
 
@@ -126,10 +126,10 @@ public class SmartDataProcessorTests
 
         // Act
         cpuMonitor.SetCpuUsage(100);
-        processor.EnqueueOrWait(1, action); // This will start the manager loop
+        processor.EnqueueOrWaitAsync(1, action).Wait(); // This will start the manager loop
         await Task.Delay(100); // Give time for the manager to update the smoothed CPU
 
-        var blockedTask = Task.Run(() => processor.EnqueueOrWait(2, action));
+        var blockedTask = Task.Run(async () => await processor.EnqueueOrWaitAsync(2, action));
 
         await Task.Delay(100);
 
@@ -164,7 +164,7 @@ public class SmartDataProcessorTests
 
         // Act
         processor.Pause();
-        processor.EnqueueOrWait(1, action);
+        await processor.EnqueueOrWaitAsync(1, action);
         await Task.Delay(100);
 
         // Assert
@@ -192,7 +192,7 @@ public class SmartDataProcessorTests
         };
 
         // Act
-        processor.EnqueueOrWait(1, action);
+        processor.EnqueueOrWaitAsync(1, action).Wait();
         await processor.WaitForAllAsync();
 
         // Assert


### PR DESCRIPTION
Changing EnqueueOrWait to EnqueueOrWaitAsync, making it awaitable so that it doesn't block the main thread when called.

While here also adding:
- A TPL Dataflow example using ActionBlock
- Updating readme and nuget docs